### PR TITLE
filter: Keep start/end sync and -p implies raw mode and hiding cursor; added ap_stdin_ready() and ap_str() shortcut and more to ansipixels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,16 @@ clean:
 update-headers:
 	./scripts/update_headers.sh
 
+
+GPERF_LIB_DIR ?= /usr/local/lib
+
+profile-demos:
+	make clean demo-binaries OPTS="-g -O2" LDFLAGS="-lprofiler -L $(GPERF_LIB_DIR)" SAN= DEBUG=0
+
 local-check:
 	./scripts/run.sh
 
 # later... add unit tests
 test:
 
-.PHONY: clean all format update-headers run-fps ci-check test local-check
+.PHONY: clean all format update-headers run-fps ci-check test local-check profile-demos

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ update-headers:
 GPERF_LIB_DIR ?= /usr/local/lib
 
 profile-demos:
-	make clean demo-binaries OPTS="-g -O2" LDFLAGS="-lprofiler -L $(GPERF_LIB_DIR)" SAN= DEBUG=0
+	make clean demo-binaries OPTS="-g -O2" LDFLAGS="-L $(GPERF_LIB_DIR) -lprofiler" SAN= DEBUG=0
 
 local-check:
 	./scripts/run.sh

--- a/demos/ansipixels_demo.c
+++ b/demos/ansipixels_demo.c
@@ -23,7 +23,7 @@ int main(void) {
     ssize_t written = write_buf(STDOUT_FILENO, b);
     LOG_DEBUG("Wrote %zd bytes", written);
 
-    b.size = 0; // clear/reset/reuse
+    clear_buf(&b); // clear/reset/reuse
     append_str(&b, UTF8("Hello, 🌎!\n"));
     // same: debug print & output stdout
     debug_print_buf(b);
@@ -58,7 +58,7 @@ int main(void) {
             last_w = ap->w;
             last_h = ap->h;
         }
-        b.size = 0; // clear buffer for reuse
+        clear_buf(&b); // clear buffer for reuse
         ssize_t n = read_buf(STDIN_FILENO, &b);
         if (n < 0) {
             if (errno == EINTR) {
@@ -76,7 +76,7 @@ int main(void) {
         // write_buf(STDOUT_FILENO, b);
         const char *fc;
         static const char endlist[] = {'\x03', '\x04'}; // Ctrl-C and Ctrl-D
-        if ((fc = mempbrk(b.data, b.size, endlist, sizeof(endlist))) != NULL) {
+        if ((fc = mempbrk(b.data + b.start, b.size, endlist, sizeof(endlist))) != NULL) {
             LOG_DEBUG("Exit character %d found at offset %zd, exiting.", *fc, fc - b.data);
             break; // exit on 'Ctrl-C' or 'Ctrl-D' press
         }

--- a/demos/ansipixels_demo.c
+++ b/demos/ansipixels_demo.c
@@ -48,7 +48,7 @@ int main(void) {
             ap_start(ap);
             ap_clear_screen(ap, false); // buffered clear to avoid flicker on resize
             ap_move_to(ap, ap->w / 2 - 10, ap->h / 2 - 1);
-            append_str(&ap->buf, STR("Size changed: "));
+            ap_str(ap, STR("Size changed: "));
             ap_itoa(ap, ap->w);
             append_byte(&ap->buf, 'x');
             ap_itoa(ap, ap->h);

--- a/demos/filter.c
+++ b/demos/filter.c
@@ -21,9 +21,9 @@
 enum {
 #if DEBUG
     // short on purpose for testing to trigger potential bugs with half complete sequences.
-    BUF_SIZE = 4 // must be at least 4 as we divide by 4.
+    BUF_SIZE = 4
 #else
-    BUF_SIZE = 1 << 16
+    BUF_SIZE = 32768 // Seems fastest on macOS arm64.
 #endif
 };
 

--- a/demos/filter.c
+++ b/demos/filter.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     bool eof = false;
     do {
         // Make sure we will eventually find the end (or EOF) even with tiny test buffer size.
-        ssize_t n = read_n(ifile, &inputbuf, BUF_SIZE / 2);
+        ssize_t n = read_n(ifile, &inputbuf, BUF_SIZE);
         if (n < 0) {
             LOG_ERROR("Error reading input: %s", strerror(errno));
             return 1;

--- a/demos/filter.c
+++ b/demos/filter.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv) {
             LOG_ERROR("Error writing output: %s", strerror(errno));
             return 1;
         }
-        outbuf.size = 0; // reset output buffer for reuse
+        clear_buf(&outbuf); // reset output buffer for reuse
         totalWritten += m;
         if (new_frame_end_index > 0) {
             LOG_DEBUG("Outputting filtered clear screen sequence and text content until next frame");
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
                         ap_end(ap);
                         return 1;
                     }
-                    stdin_buf.size = 0; // reset input buffer for reuse
+                    clear_buf(&stdin_buf); // reset input buffer for reuse
                 }
             }
             // Pause at the end (!continued_processing) or if we hit a new frame.
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
                 read_buf(STDIN_FILENO, &stdin_buf); // wait for any input to exit
                 ap_hide_cursor(ap);
                 ap_flush(ap);
-                stdin_buf.size = 0; // reset input buffer for reuse
+                clear_buf(&stdin_buf); // reset input buffer for reuse
             }
         }
     } while (continue_processing);
@@ -332,5 +332,6 @@ int main(int argc, char **argv) {
     free_buf(&quoted);
     free_buf(&outbuf);
     free_buf(&inputbuf);
+    free_buf(&stdin_buf);
     return 0;
 }

--- a/demos/record.c
+++ b/demos/record.c
@@ -15,7 +15,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
-#include <sys/select.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #ifdef __APPLE__

--- a/demos/record.c
+++ b/demos/record.c
@@ -248,16 +248,16 @@ int main(int argc, char **argv) {
                 ap_save_cursor(ap);
                 ap_move_to(ap, 0, 0); // move to top
                 // Inverse colors for visibility, and show total read/written
-                append_str(&ap->buf, STR("\033[7m")); // inverse colors
-                append_str(&ap->buf, STR("R: "));
+                ap_str(ap, STR("\033[7m")); // inverse colors
+                ap_str(ap, STR("R: "));
                 ap_itoa(ap, readn);
-                append_str(&ap->buf, STR(" ("));
+                ap_str(ap, STR(" ("));
                 ap_itoa(ap, totalRead);
-                append_str(&ap->buf, STR("), W: "));
+                ap_str(ap, STR("), W: "));
                 ap_itoa(ap, writen);
-                append_str(&ap->buf, STR(" ("));
+                ap_str(ap, STR(" ("));
                 ap_itoa(ap, totalWritten);
-                append_str(&ap->buf, STR(") \033[m")); // reset colors
+                ap_str(ap, STR(") \033[m")); // reset colors
                 ap_restore_cursor(ap);
                 ap_flush(ap);
             }

--- a/include/ansipixels.h
+++ b/include/ansipixels.h
@@ -48,3 +48,6 @@ void ap_flush(ap_t ap);
 
 void ap_save_cursor(ap_t ap);
 void ap_restore_cursor(ap_t ap);
+
+void ap_hide_cursor(ap_t ap);
+void ap_show_cursor(ap_t ap);

--- a/include/ansipixels.h
+++ b/include/ansipixels.h
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <sys/errno.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 
 typedef struct ap {
     int out;
@@ -53,8 +54,5 @@ void ap_hide_cursor(ap_t ap);
 void ap_show_cursor(ap_t ap);
 
 bool ap_stdin_ready(ap_t ap);
-
-void ap_start_sync(ap_t ap);
-void ap_end_sync(ap_t ap);
 
 void ap_str(ap_t ap, string s);

--- a/include/ansipixels.h
+++ b/include/ansipixels.h
@@ -51,3 +51,10 @@ void ap_restore_cursor(ap_t ap);
 
 void ap_hide_cursor(ap_t ap);
 void ap_show_cursor(ap_t ap);
+
+bool ap_stdin_ready(ap_t ap);
+
+void ap_start_sync(ap_t ap);
+void ap_end_sync(ap_t ap);
+
+void ap_str(ap_t ap, string s);

--- a/include/buf.h
+++ b/include/buf.h
@@ -13,8 +13,9 @@
 
 typedef struct buf {
     char *data;
-    size_t size;
-    size_t cap;
+    size_t start; // offset from data for start of current non consumed data
+    size_t size;  // logical size of the data starting at data + start
+    size_t cap;   // total allocated capacity starting at data
 #if DEBUG
     int allocs; // for debugging reallocs
 #endif
@@ -22,6 +23,8 @@ typedef struct buf {
 
 buffer new_buf(size_t size);
 void free_buf(buffer *b);
+// Move data to start, resets start to 0 and keeps size unchanged.
+void compact(buffer *b);
 void ensure_cap(buffer *dest, size_t new_cap);
 
 ssize_t read_buf(int fd, buffer *b);

--- a/include/buf.h
+++ b/include/buf.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 #include "str.h"
+#include <stdbool.h>
 #include <unistd.h>
 
 typedef struct buf {
@@ -23,9 +24,12 @@ typedef struct buf {
 
 buffer new_buf(size_t size);
 void free_buf(buffer *b);
-// Move data to start, resets start to 0 and keeps size unchanged.
-void compact(buffer *b);
-void ensure_cap(buffer *dest, size_t new_cap);
+void clear_buf(buffer *b);
+// Copy non overlapping data to start, resets start to 0 and keeps size unchanged.
+// Returns true if compaction was actually done.
+bool compact(buffer *b);
+void ensure_cap(buffer *b, size_t new_cap);
+void ensure_room(buffer *b, size_t sz);
 
 ssize_t read_buf(int fd, buffer *b);
 

--- a/src/ansipixels.c
+++ b/src/ansipixels.c
@@ -121,7 +121,7 @@ void ap_clear_screen(ap_t ap, bool immediate) {
 }
 
 void ap_start(ap_t ap) {
-    ap->buf.size = 0;
+    clear_buf(&ap->buf);            // reset buffer for new batch of commands
     ap_str(ap, STR("\033[?2026h")); // start sync/batch mode
 }
 
@@ -155,7 +155,7 @@ void ap_move_to(ap_t ap, int x, int y) {
 
 void ap_flush(ap_t ap) {
     write_buf(ap->out, ap->buf);
-    ap->buf.size = 0;
+    clear_buf(&ap->buf);
 }
 
 void ap_save_cursor(ap_t ap) {

--- a/src/ansipixels.c
+++ b/src/ansipixels.c
@@ -177,6 +177,7 @@ void ap_show_cursor(ap_t ap) {
 
 // Poll stdin without changing file status flags (which may be shared with stdout/stderr on a tty).
 bool ap_stdin_ready(ap_t _) {
+    (void)_;  // mark as unused for now.
     fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(STDIN_FILENO, &rfds);

--- a/src/ansipixels.c
+++ b/src/ansipixels.c
@@ -127,8 +127,7 @@ void ap_start(ap_t ap) {
 
 void ap_end(ap_t ap) {
     ap_str(ap, STR("\033[?2026l")); // end sync/batch mode
-    write_buf(ap->out, ap->buf);
-    ap->buf.size = 0;
+    ap_flush(ap);
 }
 
 void ap_itoa(ap_t ap, int n) {
@@ -177,7 +176,7 @@ void ap_show_cursor(ap_t ap) {
 
 // Poll stdin without changing file status flags (which may be shared with stdout/stderr on a tty).
 bool ap_stdin_ready(ap_t _) {
-    (void)_;  // mark as unused for now.
+    (void)_; // mark as unused for now.
     fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(STDIN_FILENO, &rfds);
@@ -192,15 +191,4 @@ bool ap_stdin_ready(ap_t _) {
     return r > 0 && FD_ISSET(STDIN_FILENO, &rfds);
 }
 
-void ap_start_sync(ap_t ap) {
-    ap_str(ap, STR("\033[?2026h")); // start sync/batch mode
-}
-
-void ap_end_sync(ap_t ap) {
-    ap_str(ap, STR("\033[?2026l")); // end sync/batch mode
-    ap_flush(ap);
-}
-
-void ap_str(ap_t ap, string s) {
-    append_data(&ap->buf, s.data, s.size);
-}
+void ap_str(ap_t ap, string s) { append_data(&ap->buf, s.data, s.size); }

--- a/src/ansipixels.c
+++ b/src/ansipixels.c
@@ -50,6 +50,7 @@ void ap_cleanup(void) {
     if (!global_ap) {
         return; // nothing to clean up
     }
+    ap_show_cursor(global_ap);
     ap_end(global_ap);
     ap_paste_off(global_ap);
     term_restore();
@@ -164,4 +165,12 @@ void ap_save_cursor(ap_t ap) {
 
 void ap_restore_cursor(ap_t ap) {
     append_str(&ap->buf, STR("\0338")); // restore cursor position
+}
+
+void ap_hide_cursor(ap_t ap) {
+    append_str(&ap->buf, STR("\033[?25l")); // hide cursor
+}
+
+void ap_show_cursor(ap_t ap) {
+    append_str(&ap->buf, STR("\033[?25h")); // show cursor
 }

--- a/src/ansipixels.c
+++ b/src/ansipixels.c
@@ -117,16 +117,16 @@ void ap_clear_screen(ap_t ap, bool immediate) {
         write_str(ap->out, what);
         return;
     }
-    append_str(&ap->buf, what);
+    ap_str(ap, what);
 }
 
 void ap_start(ap_t ap) {
     ap->buf.size = 0;
-    append_str(&ap->buf, STR("\033[?2026h")); // start sync/batch mode
+    ap_str(ap, STR("\033[?2026h")); // start sync/batch mode
 }
 
 void ap_end(ap_t ap) {
-    append_str(&ap->buf, STR("\033[?2026l")); // end sync/batch mode
+    ap_str(ap, STR("\033[?2026l")); // end sync/batch mode
     write_buf(ap->out, ap->buf);
     ap->buf.size = 0;
 }
@@ -147,7 +147,7 @@ void ap_itoa(ap_t ap, int n) {
 }
 
 void ap_move_to(ap_t ap, int x, int y) {
-    append_str(&ap->buf, STR("\033["));
+    ap_str(ap, STR("\033["));
     ap_itoa(ap, y + 1); // ANSI rows are 1-based
     append_byte(&ap->buf, ';');
     ap_itoa(ap, x + 1); // ANSI columns are 1-based
@@ -160,17 +160,46 @@ void ap_flush(ap_t ap) {
 }
 
 void ap_save_cursor(ap_t ap) {
-    append_str(&ap->buf, STR("\0337")); // save cursor position
+    ap_str(ap, STR("\0337")); // save cursor position
 }
 
 void ap_restore_cursor(ap_t ap) {
-    append_str(&ap->buf, STR("\0338")); // restore cursor position
+    ap_str(ap, STR("\0338")); // restore cursor position
 }
 
 void ap_hide_cursor(ap_t ap) {
-    append_str(&ap->buf, STR("\033[?25l")); // hide cursor
+    ap_str(ap, STR("\033[?25l")); // hide cursor
 }
 
 void ap_show_cursor(ap_t ap) {
-    append_str(&ap->buf, STR("\033[?25h")); // show cursor
+    ap_str(ap, STR("\033[?25h")); // show cursor
+}
+
+// Poll stdin without changing file status flags (which may be shared with stdout/stderr on a tty).
+bool ap_stdin_ready(ap_t _) {
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(STDIN_FILENO, &rfds);
+    struct timeval tv = {0, 0};
+    int r = select(STDIN_FILENO + 1, &rfds, NULL, NULL, &tv);
+    if (r < 0) {
+        if (errno != EINTR) {
+            LOG_ERROR("Error polling stdin: %s", strerror(errno));
+        }
+        return false;
+    }
+    return r > 0 && FD_ISSET(STDIN_FILENO, &rfds);
+}
+
+void ap_start_sync(ap_t ap) {
+    ap_str(ap, STR("\033[?2026h")); // start sync/batch mode
+}
+
+void ap_end_sync(ap_t ap) {
+    ap_str(ap, STR("\033[?2026l")); // end sync/batch mode
+    ap_flush(ap);
+}
+
+void ap_str(ap_t ap, string s) {
+    append_data(&ap->buf, s.data, s.size);
 }

--- a/src/buf.c
+++ b/src/buf.c
@@ -69,7 +69,7 @@ ssize_t read_n(int fd, buffer *b, size_t n) {
 }
 
 void compact(buffer *b) {
-    if (b->start > 0 && b->size < b->start) {
+    if (b->size > 0 && b->start >= b->size) {
         memcpy(b->data, b->data + b->start, b->size);
         b->start = 0;
     }

--- a/src/buf.c
+++ b/src/buf.c
@@ -119,6 +119,10 @@ void append_str(buffer *dest, string src) { append_data(dest, src.data, src.size
 void append_byte(buffer *dest, char byte) { append_data(dest, &byte, 1); }
 
 buffer slice_buf(buffer b, size_t start, size_t end) {
+    if (end > b.size) {
+        end = b.size; // allow slice end to be after end of buffer but clamp it to buffer size to avoid out of bounds
+                      // access
+    }
     return (buffer){
         b.data + start,
         end - start,

--- a/src/buf.c
+++ b/src/buf.c
@@ -167,7 +167,7 @@ buffer debug_quote(const char *s, size_t size) {
     return b;
 }
 
-const char *debug_buf(buffer *shared_buf, buffer b) { return debug_data(shared_buf, b.data, b.size); }
+const char *debug_buf(buffer *shared_buf, buffer b) { return debug_data(shared_buf, b.data + b.start, b.size); }
 
 const char *debug_data(buffer *shared_buf, const char *data, size_t size) {
     shared_buf->size = 0; // reset shared buffer for reuse
@@ -210,13 +210,14 @@ void quote_buf(buffer *b, const char *s, size_t size) {
 }
 
 void debug_print_buf(buffer b) {
-    buffer quoted = debug_quote(b.data, b.size);
+    buffer quoted = debug_quote(b.data + b.start, b.size);
     fprintf(
         stderr,
-        GREEN "INF buffer { data: %p = %s, size: %zu, cap: %zu, allocs: %d/%d "
+        GREEN "INF buffer { data: %p = %s, start: %zu, size: %zu, cap: %zu, allocs: %d/%d "
               "}" END_LOG,
         (void *)b.data,
         quoted.data,
+        b.start,
         b.size,
         b.cap,
 #if DEBUG
@@ -262,4 +263,4 @@ ssize_t write_all(int fd, const char *buf, ssize_t len) {
     return total;
 }
 
-ssize_t write_buf(int fd, buffer b) { return write_all(fd, b.data, b.size); }
+ssize_t write_buf(int fd, buffer b) { return write_all(fd, b.data + b.start, b.size); }

--- a/src/buf.c
+++ b/src/buf.c
@@ -69,8 +69,8 @@ ssize_t read_n(int fd, buffer *b, size_t n) {
 }
 
 void compact(buffer *b) {
-    if (b->start > 0) {
-        memmove(b->data, b->data + b->start, b->size);
+    if (b->start > 0 && b->size < b->start) {
+        memcpy(b->data, b->data + b->start, b->size);
         b->start = 0;
     }
 }
@@ -124,8 +124,9 @@ void ensure_cap(buffer *dest, size_t new_cap) {
 }
 
 void append_data(buffer *dest, const char *data, size_t size) {
-    ensure_cap(dest, dest->size + size);
-    memcpy(dest->data + dest->size, data, size);
+    size_t current_end = dest->start + dest->size;
+    ensure_cap(dest, current_end + size);
+    memcpy(dest->data + current_end, data, size);
     dest->size += size;
 }
 


### PR DESCRIPTION
# main branch (v0.10.0):

```sh
git switch main
make clean filter DEBUG=0 SAN=  && time ./filter fps.rec
```

INF demos/filter.c:252: Total read: 406394183 bytes, written : 406259821 bytes, frames processed: 3────────────┘

real    0m22.960s
user    0m18.415s
sys     0m1.615s

- fixed memory
- cpu : 88% filter 46% ghostty

# paging branch initially - before perf check and fixes:
```sh
git switch paging
make clean filter DEBUG=0 SAN= && time ./filter fps.rec
```

INF demos/filter.c:329: Total read: 406394183 bytes, written : 406367269 bytes, frames processed: 3────────────┘

real    210m50.956s
user    209m41.442s
sys     0m15.762s

- memory increases over time, gets slower over time
- cpu maxed at 99.x% ghostty 1.2% -> 0.6 -> 0.5 (window not visible, back to 1% when visible)

Quite the huge regression/issue - had to do with constantly memmoving data into the large buffer

Instead we do it after processing as much as the input possible via move/copy and only if non overlapping.

Note we could also potentially just write the sequences as we find a block (ie reuse the input buffer) but that wouldn't work well with lots of filtering

# after fix

$ time ./filter fps.rec > /dev/null
INF demos/filter.c:235: Filtering ANSI sequences from 'fps.rec', buf size 65536, default mode, frames limit: -1
INF demos/filter.c:332: Total read: 406394183 bytes, written : 406367269 bytes, frames processed: 3

real    0m0.500s
user    0m0.449s
sys     0m0.047s

 (if I let ghostty display them it's real    0m4.574s)



```
hyperfine "./filter fps.rec > /dev/null"
```

Time (mean ± σ):     498.7 ms ±  13.7 ms    [User: 453.4 ms, System: 37.2 ms]
